### PR TITLE
refactor: Using right syntax for importing aws-cdk-lib modules, also using node 16 

### DIFF
--- a/bin/document-ledger.ts
+++ b/bin/document-ledger.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib'
 
 import { FoundationStack } from '../stacks/foundation-stack';
 import { LedgerStack } from '../stacks/ledger-stack';

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -17,7 +17,8 @@ fi
 
 
 echo "Installing OS packages"
-sudo yum update && sudo yum install -y postgresql14.x86_64 postgresql14-server -y
+sudo amazon-linux-extras enable postgresql14
+sudo yum update && sudo yum install -y postgresql -y
 
 
 echo "Installing latest CDK"

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -17,7 +17,7 @@ fi
 
 
 echo "Installing OS packages"
-sudo yum install -y postgresql
+sudo yum update && sudo yum install -y postgresql14.x86_64 postgresql14-server -y
 
 
 echo "Installing latest CDK"

--- a/stacks/explorer-stack.ts
+++ b/stacks/explorer-stack.ts
@@ -51,7 +51,7 @@ export class ExplorerStack extends cdk.Stack {
     });
 
     const database = new rds.DatabaseInstance(this, 'Database', {
-      engine: rds.DatabaseInstanceEngine.postgres({version: rds.PostgresEngineVersion.VER_16}),
+      engine: rds.DatabaseInstanceEngine.postgres({version: rds.PostgresEngineVersion.VER_14_1}),
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),
       vpc: defaultVpc,
       vpcSubnets: {subnets: databaseSubnets},

--- a/stacks/explorer-stack.ts
+++ b/stacks/explorer-stack.ts
@@ -51,7 +51,7 @@ export class ExplorerStack extends cdk.Stack {
     });
 
     const database = new rds.DatabaseInstance(this, 'Database', {
-      engine: rds.DatabaseInstanceEngine.postgres({version: rds.PostgresEngineVersion.VER_12}),
+      engine: rds.DatabaseInstanceEngine.postgres({version: rds.PostgresEngineVersion.VER_16}),
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),
       vpc: defaultVpc,
       vpcSubnets: {subnets: databaseSubnets},

--- a/stacks/explorer-stack.ts
+++ b/stacks/explorer-stack.ts
@@ -4,7 +4,7 @@
 import * as os from 'os';
 
 import * as constructs from 'constructs';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib'
 import * as cm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets';

--- a/stacks/foundation-stack.ts
+++ b/stacks/foundation-stack.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import * as constructs from 'constructs';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib'
 import * as r53 from 'aws-cdk-lib/aws-route53';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 

--- a/stacks/interface-stack.ts
+++ b/stacks/interface-stack.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 
 import * as constructs from 'constructs';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib'
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as cm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';

--- a/stacks/interface-stack.ts
+++ b/stacks/interface-stack.ts
@@ -65,7 +65,7 @@ export class InterfaceStack extends cdk.Stack {
     });
 
     const authorizerFunction = new lambda.Function(this, 'ApiAuthorizerFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       code: lambda.AssetCode.fromAsset(path.join(__dirname, '../lambdas/authorizer')),
       handler: 'index.handler',
       environment: {

--- a/stacks/interface-stack.ts
+++ b/stacks/interface-stack.ts
@@ -79,7 +79,7 @@ export class InterfaceStack extends cdk.Stack {
     apiWriterToken.grantRead(authorizerFunction);
 
     const apiLambdaLayer = new lambda.LayerVersion(this, 'ApiLambdaLayer', {
-      compatibleRuntimes: [lambda.Runtime.NODEJS_12_X],
+      compatibleRuntimes: [lambda.Runtime.NODEJS_16_X],
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambdas/layer')),
     });
 
@@ -88,7 +88,7 @@ export class InterfaceStack extends cdk.Stack {
       vpcSubnets: {subnets: apiVpc.isolatedSubnets},
       memorySize: 256,
       timeout: cdk.Duration.seconds(10.0),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       layers: [apiLambdaLayer],
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambdas/reader')),
       handler: 'index.handler',
@@ -109,7 +109,7 @@ export class InterfaceStack extends cdk.Stack {
       vpcSubnets: {subnets: apiVpc.isolatedSubnets},
       memorySize: 256,
       timeout: cdk.Duration.seconds(10.0),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       layers: [apiLambdaLayer],
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambdas/writer')),
       handler: 'index.handler',

--- a/stacks/ledger-stack.ts
+++ b/stacks/ledger-stack.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import * as constructs from 'constructs';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib'
 import * as cr from 'aws-cdk-lib/custom-resources';
 import * as managedblockchain from 'aws-cdk-lib/aws-managedblockchain';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';


### PR DESCRIPTION
*Description of changes:*
Having problems when creating the stacks.
I made some research and discovered that this is related to old way of importing the cdk modules from aws-cdk-lib.
This PR, fix the imports for:
- `bin/document-ledger.ts`
- `stacks\explorer-stack.ts`
- `stacks\foundation-stack.ts`
- `stacks\interface-stack.ts`
- `stacks\ledger-stack.ts`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
